### PR TITLE
Add synthetic dataset generation and prediction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# E-Commerce-Consumer-Behaviour-Prediction
+# E-Commerce Consumer Behaviour Prediction
+
+This project demonstrates a simple workflow for generating a synthetic e-commerce
+transactions dataset and training a logistic regression model to predict whether
+a customer will make a purchase.
+
+## Requirements
+- Python 3.8+
+- pandas
+- numpy
+- scikit-learn
+- pytest (for running tests)
+
+Install dependencies with:
+
+```bash
+pip install pandas numpy scikit-learn pytest
+```
+
+## Usage
+
+1. **Generate the dataset**
+   ```bash
+   python src/generate_dataset.py
+   ```
+   This will create `data/sample_transactions.csv`.
+
+2. **Train the model**
+   ```bash
+   python src/train_model.py
+   ```
+   The script will print the accuracy of the trained model.
+
+3. **Run tests**
+   ```bash
+   pytest -q
+   ```
+
+The dataset is randomly generated, so results may vary between runs.

--- a/src/generate_dataset.py
+++ b/src/generate_dataset.py
@@ -1,0 +1,37 @@
+"""Generate a synthetic e-commerce transactions dataset."""
+
+import numpy as np
+import pandas as pd
+
+
+def generate_dataset(n: int = 1000) -> pd.DataFrame:
+    np.random.seed(42)
+    data = {
+        'Age': np.random.randint(18, 70, size=n),
+        'Gender': np.random.randint(0, 2, size=n),  # 0=Female, 1=Male
+        'BrowsingTime': np.random.normal(10, 5, size=n).clip(min=0),
+        'PagesVisited': np.random.poisson(5, size=n),
+        'AddToCart': np.random.randint(0, 2, size=n)
+    }
+
+    prob_purchase = (
+        0.3 * (data['Age'] > 30).astype(int)
+        + 0.2 * data['Gender']
+        + 0.2 * (data['BrowsingTime'] > 10).astype(int)
+        + 0.3 * data['AddToCart']
+    )
+    labels = (prob_purchase + np.random.rand(n) > 1.2).astype(int)
+
+    df = pd.DataFrame(data)
+    df['Purchase'] = labels
+    return df
+
+
+def save_dataset(path: str = 'data/sample_transactions.csv', n: int = 1000) -> None:
+    df = generate_dataset(n)
+    df.to_csv(path, index=False)
+    print(f'Dataset saved to {path}')
+
+
+if __name__ == '__main__':
+    save_dataset()

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.metrics import accuracy_score
+
+
+def load_data(path: str = 'data/sample_transactions.csv') -> pd.DataFrame:
+    """Load the transaction dataset from CSV."""
+    return pd.read_csv(path)
+
+
+def build_pipeline() -> Pipeline:
+    """Create the ML pipeline."""
+    pipeline = Pipeline([
+        ('scaler', StandardScaler()),
+        ('clf', LogisticRegression(max_iter=1000))
+    ])
+    return pipeline
+
+
+def train_and_evaluate(df: pd.DataFrame) -> float:
+    X = df.drop('Purchase', axis=1)
+    y = df['Purchase']
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = build_pipeline()
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    return acc
+
+
+def main():
+    df = load_data()
+    acc = train_and_evaluate(df)
+    print(f'Accuracy: {acc:.3f}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.generate_dataset import generate_dataset, save_dataset
+from src.train_model import train_and_evaluate
+
+
+def setup_module(module):
+    # Ensure dataset exists for tests
+    save_dataset()
+
+
+def test_dataset_exists():
+    assert os.path.exists('data/sample_transactions.csv'), 'Dataset file missing'
+
+
+def test_model_training():
+    df = generate_dataset()
+    acc = train_and_evaluate(df)
+    assert 0 <= acc <= 1


### PR DESCRIPTION
## Summary
- generate a synthetic e-commerce dataset
- add logistic regression training pipeline
- provide simple tests
- update README with usage instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841df8059508330b64c4e84c7334440